### PR TITLE
Suppress AR logging messages when recording cruft

### DIFF
--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.1)
+    is_this_used (0.1.2)
       activerecord (>= 5.2)
 
 GEM

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.1)
+    is_this_used (0.1.2)
       activerecord (>= 5.2)
 
 GEM

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.1)
+    is_this_used (0.1.2)
       activerecord (>= 5.2)
 
 GEM

--- a/lib/is_this_used.rb
+++ b/lib/is_this_used.rb
@@ -2,6 +2,7 @@ require 'is_this_used/version'
 require 'is_this_used/cruft_tracker'
 require 'is_this_used/models/potential_cruft'
 require 'is_this_used/models/potential_cruft_stack'
+require 'is_this_used/util/log_suppressor'
 
 module IsThisUsed
   class Error < StandardError; end

--- a/lib/is_this_used/util/log_suppressor.rb
+++ b/lib/is_this_used/util/log_suppressor.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module IsThisUsed
+  module Util
+    class LogSuppressor
+      def self.suppress_logging
+        initial_log_level = ActiveRecord::Base.logger.level
+        ActiveRecord::Base.logger.level = :error
+        yield
+        ActiveRecord::Base.logger.level = initial_log_level
+      end
+    end
+  end
+end

--- a/lib/is_this_used/version.rb
+++ b/lib/is_this_used/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IsThisUsed
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/is_this_used_spec.rb
+++ b/spec/is_this_used_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe IsThisUsed do
   it 'has a version number' do
     expect(IsThisUsed::VERSION).not_to be nil
   end
-
-  # it 'does something useful' do
-  #   expect(false).to eq(true)
-  # end
 end


### PR DESCRIPTION
This commit suppresses ActiveRecord log output when recording cruft.
This can look a lot like errors in logs, especially when we're recording
stacks.