### PR TITLE
Stop using class_methods method

### DIFF
--- a/lib/is_this_used/cruft_tracker.rb
+++ b/lib/is_this_used/cruft_tracker.rb
@@ -2,8 +2,6 @@
 
 module IsThisUsed
   module CruftTracker
-    extend ActiveSupport::Concern
-
     INSTANCE_METHOD = 'instance_method'
     CLASS_METHOD = 'class_method'
 
@@ -53,7 +51,11 @@ module IsThisUsed
       end
     end
 
-    class_methods do
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
       def is_this_used?(method_name, method_type: nil)
         IsThisUsed::Util::LogSuppressor.suppress_logging do
           method_type ||= determine_method_type(method_name)

--- a/lib/is_this_used/version.rb
+++ b/lib/is_this_used/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IsThisUsed
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
For some reason I haven't yet figured out, using the `class_methods` methods from ActiveSupport sometimes raised errors in applications. 

Imagine this, you have a class, it includes `IsThisUsed::CruftTracker`. You'd expect the class methods to be ready to go, but subsequent uses of `is_this_used?` would raise an error saying the class method didn't exist. Switching away from using `class_methods` to the regular Ruby way of extending `ClassMethods` appeared to work correctly and not cause any tests to fail.