### PR TITLE
Catch errors when the DB is not present

### DIFF
--- a/lib/is_this_used/cruft_tracker.rb
+++ b/lib/is_this_used/cruft_tracker.rb
@@ -85,6 +85,10 @@ module IsThisUsed
         Rails.logger.warn(
           'There was an error recording potential cruft. Does the potential_crufts table exist?'
         )
+      rescue Mysql2::Error::ConnectionError
+        Rails.logger.warn(
+          'There was an error recording potential cruft due to being unable to connect to the database. This may be a non-issue in cases where the database is intentionally not available.'
+        )
       end
 
       def target_method(method_name, method_type)

--- a/lib/is_this_used/version.rb
+++ b/lib/is_this_used/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IsThisUsed
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
Sometimes it's possible that a class that uses ITU is loaded when a database is not available. ITU should not raise an error and prevent the application from doing what it's supposed to. 

This PR updates the `is_this_used?` to connect MySQL connection errors and print a warning.
