### PR TITLE
Catch `ActiveRecord::ConnectionNotEstablished` errors

### DIFF
--- a/lib/is_this_used/cruft_tracker.rb
+++ b/lib/is_this_used/cruft_tracker.rb
@@ -85,7 +85,7 @@ module IsThisUsed
         Rails.logger.warn(
           'There was an error recording potential cruft. Does the potential_crufts table exist?'
         )
-      rescue Mysql2::Error::ConnectionError
+      rescue Mysql2::Error::ConnectionError, ActiveRecord::ConnectionNotEstablished
         Rails.logger.warn(
           'There was an error recording potential cruft due to being unable to connect to the database. This may be a non-issue in cases where the database is intentionally not available.'
         )

--- a/lib/is_this_used/version.rb
+++ b/lib/is_this_used/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IsThisUsed
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
These errors are being thrown in Rails 6.1 when a database connection is not available. This is expected at times, like during asset compilation.

Would you be able to release a new version with this change included as well?

