### PR TITLE
Add mechanism to automatically cleanup potential cruft records

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Have you ever asked yourself, "Is this method even being used?!" Does your application use ActiveRecord? If the answers
+Have you ever asked yourself, "Is this method even being used?!" Does your application use Rails and ActiveRecord? If the answers
 to these two questions are yes, this gem may be of use to you!
 
 Large applications can accrue cruft; old methods that might once have been important, but are now unused. Unfortunately,
@@ -217,6 +217,7 @@ This model represents information about arguments provided to a specific `potent
 
 ## Dependencies
 
+* Rails - Versions 5.2, 6, and 6.1 are supported.
 * ActiveRecord - ActiveRecord is used to persist information about potentially crufty methods. This gem should happily
   work with AR 5.2, 6, and 6.1.
 * MySQL - As of now, only MySQL is supported. PRs are welcome to add support for Postgres, etc.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ end
 What do you get out of this? Well, as soon as Ruby loads the `SomeOldClass` class, is_this_used will create a new record
 in the `potential_crufts` table that looks like this:
 
-| id  | owner_name   | method_name     | method_type     | invocations | created_at          | updated_at          |
-| --- | ------------ | --------------- | --------------- | ----------- | ------------------- | ------------------- |
-| 1   | SomeOldClass | some_old_method | instance_method | 0           | 2022-01-21 14:07:48 | 2022-01-21 14:07:48 |
+| id  | owner_name   | method_name     | method_type     | invocations | deleted_at | created_at          | updated_at          |
+| --- | ------------ | --------------- | --------------- | ----------- | ---------- | ------------------- | ------------------- |
+| 1   | SomeOldClass | some_old_method | instance_method | 0           | null       | 2022-01-21 14:07:48 | 2022-01-21 14:07:48 | 
 
 This is easily accessed using the `IsThisUsed::PotentialCruft` model class.
 
@@ -87,6 +87,7 @@ The fields are:
 - `method_type` - This is either "instance_method" or "class_method", which are the values of the corresponding
   constants, `IsThisUsed::CruftTracker::INSTANCE_METHOD` and `IsThisUsed::CruftTracker::CLASS_METHOD`.
 - `invocations` - The number of times the method has been invoked.
+- `deleted_at` - When set, this indicates that the method is no longer being tracked.
 - `created_at` - The date/time we started tracking the method.
 - `updated_at` - The last time this record was updated. IE: the last time the tracked method was invoked.
 
@@ -249,12 +250,6 @@ cp config/database.mysql.yml config/database.yml
 ```
 
 Edit the database.yml as needed and fire up your MySQL server.
-
-You'll need to create your database (it doesn't matter which version of rails you specify):
-
-```bash
-bundle exec appraisal rails-6.1 rspec spec
-```
 
 You can now run the test suite:
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,12 @@ cp config/database.mysql.yml config/database.yml
 
 Edit the database.yml as needed and fire up your MySQL server.
 
+You'll need to create your database (it doesn't matter which version of rails you specify):
+
+```bash
+bundle exec appraisal rails-6.1 rspec spec
+```
+
 You can now run the test suite:
 
 ### Rails 5.2

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,24 @@
-# require "bundler/gem_tasks"
-require "rspec/core/rake_task"
-RSpec::Core::RakeTask.new(:spec)
+# frozen_string_literal: true
 
-task :default => :spec
+require "fileutils"
+require "bundler"
+require './spec/support/is_this_used_spec_migrator'
+Bundler::GemHelper.install_tasks
+
+desc "Create the database."
+task :create_db do
+  ENV['RAILS_ENV'] = 'test'
+  system "mysqladmin -f -h #{ENV.fetch('IS_THIS_USED_DB_HOST', 'localhost')} -P #{ENV.fetch('IS_THIS_USED_DB_PORT', 3306)} -u #{ENV.fetch('IS_THIS_USED_DB_USER', 'root')} --password=#{ENV.fetch('IS_THIS_USED_DB_PASSWORD', 'dev')} drop is_this_used_test"
+  system "mysqladmin -h #{ENV.fetch('IS_THIS_USED_DB_HOST', 'localhost')} -P #{ENV.fetch('IS_THIS_USED_DB_PORT', 3306)} -u #{ENV.fetch('IS_THIS_USED_DB_USER', 'root')} --password=#{ENV.fetch('IS_THIS_USED_DB_PASSWORD', 'dev')} create is_this_used_test"
+
+  Bundler.setup
+  require 'active_record/railtie'
+  require 'is_this_used'
+  require 'rspec/rails'
+
+  require File.expand_path('spec/dummy_app/config/environment', __dir__)
+  ::IsThisUsedSpecMigrator.new.migrate
+end
+
+desc "Default: run all available test suites"
+task default: :spec

--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.5)
+    is_this_used (0.1.7)
       activerecord (>= 5.2)
 
 GEM

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.5)
+    is_this_used (0.1.7)
       activerecord (>= 5.2)
 
 GEM

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.5)
+    is_this_used (0.1.7)
       activerecord (>= 5.2)
 
 GEM

--- a/lib/generators/is_this_used/templates/create_potential_crufts.rb.erb
+++ b/lib/generators/is_this_used/templates/create_potential_crufts.rb.erb
@@ -6,6 +6,7 @@ class CreatePotentialCrufts < ActiveRecord::Migration<%= migration_version %>
       t.string :method_name, null: false
       t.string :method_type, null: false
       t.integer :invocations, null: false, default: 0
+      t.datetime :deleted_at
       t.timestamps
 
       t.index :owner_name

--- a/lib/is_this_used.rb
+++ b/lib/is_this_used.rb
@@ -1,6 +1,7 @@
 require 'is_this_used/version'
 require 'is_this_used/cruft_tracker'
 require 'is_this_used/cruft_cleaner'
+require 'is_this_used/registry'
 require 'is_this_used/models/potential_cruft'
 require 'is_this_used/models/potential_cruft_stack'
 require 'is_this_used/models/potential_cruft_argument'

--- a/lib/is_this_used.rb
+++ b/lib/is_this_used.rb
@@ -8,3 +8,6 @@ require 'is_this_used/util/log_suppressor'
 module IsThisUsed
   class Error < StandardError; end
 end
+
+require 'is_this_used/railtie' if defined?(Rails)
+

--- a/lib/is_this_used.rb
+++ b/lib/is_this_used.rb
@@ -1,5 +1,6 @@
 require 'is_this_used/version'
 require 'is_this_used/cruft_tracker'
+require 'is_this_used/cruft_cleaner'
 require 'is_this_used/models/potential_cruft'
 require 'is_this_used/models/potential_cruft_stack'
 require 'is_this_used/models/potential_cruft_argument'

--- a/lib/is_this_used/cruft_cleaner.rb
+++ b/lib/is_this_used/cruft_cleaner.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module IsThisUsed
+  class CruftCleaner
+    def clean🧹
+      IsThisUsed::PotentialCruft.all.each do |potential_cruft|
+        unless potential_cruft.still_exists? && potential_cruft.still_tracked?
+          potential_cruft.update(deleted_at: Time.current)
+        end
+      end
+    end
+  end
+end

--- a/lib/is_this_used/cruft_cleaner.rb
+++ b/lib/is_this_used/cruft_cleaner.rb
@@ -2,8 +2,8 @@
 
 module IsThisUsed
   class CruftCleaner
-    def clean🧹
-      IsThisUsed::PotentialCruft.all.each do |potential_cruft|
+    def self.clean🧹
+      IsThisUsed::PotentialCruft.where(deleted_at: nil).each do |potential_cruft|
         unless potential_cruft.still_exists? && potential_cruft.still_tracked?
           potential_cruft.update(deleted_at: Time.current)
         end

--- a/lib/is_this_used/cruft_tracker.rb
+++ b/lib/is_this_used/cruft_tracker.rb
@@ -87,6 +87,8 @@ module IsThisUsed
               method_type: method_type
             )
 
+          IsThisUsed::Registry.instance << potential_cruft
+
           target_method.owner.define_method target_method.name do |*args|
             IsThisUsed::Util::LogSuppressor.suppress_logging do
               CruftTracker::Recorder.record_invocation(potential_cruft)

--- a/lib/is_this_used/models/potential_cruft.rb
+++ b/lib/is_this_used/models/potential_cruft.rb
@@ -6,5 +6,29 @@ module IsThisUsed
              dependent: :destroy, class_name: 'IsThisUsed::PotentialCruftStack'
     has_many :potential_cruft_arguments,
              dependent: :destroy, class_name: 'IsThisUsed::PotentialCruftArgument'
+
+    def still_exists?
+      class_still_exists? && method_still_exists?
+    end
+
+    private
+
+    def class_still_exists?
+      Object.const_defined?(owner_name)
+    end
+
+    def clazz
+      owner_name.constantize
+    end
+
+    def method_still_exists?
+      case method_type
+      when IsThisUsed::CruftTracker::INSTANCE_METHOD
+        (clazz.instance_methods + clazz.private_instance_methods)
+      when IsThisUsed::CruftTracker::CLASS_METHOD
+        (clazz.methods + clazz.private_methods)
+      end.
+        include?(method_name.to_sym)
+    end
   end
 end

--- a/lib/is_this_used/models/potential_cruft.rb
+++ b/lib/is_this_used/models/potential_cruft.rb
@@ -11,6 +11,16 @@ module IsThisUsed
       class_still_exists? && method_still_exists?
     end
 
+    def still_tracked?
+      IsThisUsed::Registry.instance.include?(self)
+    end
+
+    def ==(other)
+      other.owner_name == owner_name &&
+        other.method_name == method_name &&
+        other.method_type == method_type
+    end
+
     private
 
     def class_still_exists?

--- a/lib/is_this_used/railtie.rb
+++ b/lib/is_this_used/railtie.rb
@@ -2,14 +2,12 @@
 
 module IsThisUsed
   class Railtie < Rails::Railtie
-    initializer "is_this_used_railtie.configure_rails_initialization" do
-      # some initialization behavior
-      puts ">>>> got here maybe?"
+    initializer "is_this_used_railtie.configure_post_initialize_cleanup" do
 
       config.after_initialize do
-        puts ">>>> we've initialized?"
-        puts ">>>> num of cruft: #{IsThisUsed::PotentialCruft.count}"
+        IsThisUsed::CruftCleaner.new.clean🧹
       end
+
     rescue StandardError
       # Swallow all errors to prevent initialization failures.
     end

--- a/lib/is_this_used/railtie.rb
+++ b/lib/is_this_used/railtie.rb
@@ -5,7 +5,7 @@ module IsThisUsed
     initializer "is_this_used_railtie.configure_post_initialize_cleanup" do
 
       config.after_initialize do
-        IsThisUsed::CruftCleaner.new.clean🧹
+        IsThisUsed::CruftCleaner.clean🧹
       end
 
     rescue StandardError

--- a/lib/is_this_used/railtie.rb
+++ b/lib/is_this_used/railtie.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module IsThisUsed
+  class Railtie < Rails::Railtie
+    initializer "is_this_used_railtie.configure_rails_initialization" do
+      # some initialization behavior
+      puts ">>>> got here maybe?"
+
+      config.after_initialize do
+        puts ">>>> we've initialized?"
+        puts ">>>> num of cruft: #{IsThisUsed::PotentialCruft.count}"
+      end
+    end
+  end
+end

--- a/lib/is_this_used/railtie.rb
+++ b/lib/is_this_used/railtie.rb
@@ -10,6 +10,8 @@ module IsThisUsed
         puts ">>>> we've initialized?"
         puts ">>>> num of cruft: #{IsThisUsed::PotentialCruft.count}"
       end
+    rescue StandardError
+      # Swallow all errors to prevent initialization failures.
     end
   end
 end

--- a/lib/is_this_used/registry.rb
+++ b/lib/is_this_used/registry.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module IsThisUsed
+  class Registry
+    include Singleton
+
+    attr_accessor :potential_crufts
+
+    def initialize
+      @potential_crufts = []
+    end
+
+    def <<(potential_cruft)
+      potential_crufts << potential_cruft
+    end
+
+    def include?(potential_cruft)
+      potential_crufts.include?(potential_cruft)
+    end
+  end
+end

--- a/spec/cruft_cleaner_spec.rb
+++ b/spec/cruft_cleaner_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'is_this_used/cruft_tracker'
+require 'is_this_used/models/potential_cruft'
+require 'dummy_app/models/fixtures/example_cruft19'
+require 'dummy_app/models/fixtures/example_cruft20'
+
+RSpec.describe IsThisUsed::CruftTracker do
+  it 'cleans up potential cruft records for methods and classes that no longer exist' do
+    cruft_records_that_should_not_be_deleted = [
+      IsThisUsed::PotentialCruft.create(
+        owner_name: 'Fixtures::ExampleCruft19',
+        method_name: 'do_something',
+        method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD
+      ),
+      IsThisUsed::PotentialCruft.create(
+        owner_name: 'Fixtures::ExampleCruft19',
+        method_name: 'do_something_privately',
+        method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD
+      ),
+      IsThisUsed::PotentialCruft.create(
+        owner_name: 'Fixtures::ExampleCruft19',
+        method_name: 'do_something_protectidly',
+        method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD
+      ),
+      IsThisUsed::PotentialCruft.create(
+        owner_name: 'Fixtures::ExampleCruft19',
+        method_name: 'do_a_thing',
+        method_type: IsThisUsed::CruftTracker::CLASS_METHOD
+      ),
+      IsThisUsed::PotentialCruft.create(
+        owner_name: 'Fixtures::ExampleCruft19',
+        method_name: 'be_sneaky',
+        method_type: IsThisUsed::CruftTracker::CLASS_METHOD
+      )
+    ]
+    cruft_records_that_should_be_deleted = [
+      IsThisUsed::PotentialCruft.create(
+        owner_name: 'Thingy',
+        method_name: 'do_it',
+        method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD
+      ),
+      IsThisUsed::PotentialCruft.create(
+        owner_name: 'Fixtures::ExampleCruft19',
+        method_name: 'some_nonexistent_method',
+        method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD
+      ),
+      IsThisUsed::PotentialCruft.create(
+        owner_name: 'Fixtures::ExampleCruft19',
+        method_name: 'some_nonexistent_class_method',
+        method_type: IsThisUsed::CruftTracker::CLASS_METHOD
+      ),
+      IsThisUsed::PotentialCruft.create(
+        owner_name: 'Fixtures::ExampleCruft20',
+        method_name: 'do_something',
+        method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD
+      )
+    ]
+
+    IsThisUsed::CruftCleaner.clean🧹
+
+    expect(IsThisUsed::PotentialCruft.all.size).to eq(9)
+    expect(IsThisUsed::PotentialCruft.where(deleted_at: nil)).
+      to match_array(cruft_records_that_should_not_be_deleted)
+    expect(IsThisUsed::PotentialCruft.where.not(deleted_at: nil)).
+      to match_array(cruft_records_that_should_be_deleted)
+  end
+
+end

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -9,8 +9,10 @@
 # these in our spec_helper.
 # Bundler.require(:default, Rails.env)
 
+require 'rails'
+
 module Dummy
-  class Application < Rails::Application
+  class Application < ::Rails::Application
     config.load_defaults(::Rails.gem_version.segments.take(2).join('.'))
 
     config.encoding = 'utf-8'

--- a/spec/dummy_app/config/database.mysql.yml
+++ b/spec/dummy_app/config/database.mysql.yml
@@ -7,4 +7,4 @@ test: &test
   host: <%= ENV.fetch('IS_THIS_USED_DB_HOST', 'localhost') %>
   port: <%= ENV.fetch('IS_THIS_USED_DB_PORT', 3306) %>
   protocol: TCP
-  password: <%= ENV.fetch('IS_THIS_USED_DB_PASSWORD', 3306) %>
+  password: <%= ENV.fetch('IS_THIS_USED_DB_PASSWORD', 'dev') %>

--- a/spec/dummy_app/config/database.yml
+++ b/spec/dummy_app/config/database.yml
@@ -7,4 +7,4 @@ test: &test
   host: <%= ENV.fetch('IS_THIS_USED_DB_HOST', 'localhost') %>
   port: <%= ENV.fetch('IS_THIS_USED_DB_PORT', 3306) %>
   protocol: TCP
-  password: <%= ENV.fetch('IS_THIS_USED_DB_PASSWORD', 3306) %>
+  password: <%= ENV.fetch('IS_THIS_USED_DB_PASSWORD', 'dev') %>

--- a/spec/dummy_app/db/migrate/20220120084312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20220120084312_set_up_test_tables.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # This migration must be kept in sync with
+# `lib/generators/is_this_used/templates/create_potential_cruft_arguments.rb.erb`
 # `lib/generators/is_this_used/templates/create_potential_cruft_stacks.rb.erb`
 # `lib/generators/is_this_used/templates/create_potential_crufts.rb.erb`
 #
@@ -11,6 +12,7 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.string :method_name, null: false
       t.string :method_type, null: false
       t.integer :invocations, null: false, default: 0
+      t.datetime :deleted_at
       t.timestamps
 
       t.index :owner_name

--- a/spec/dummy_app/models/fixtures/example_cruft19.rb
+++ b/spec/dummy_app/models/fixtures/example_cruft19.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'is_this_used/cruft_tracker'
+
+module Fixtures
+  class ExampleCruft19
+    include IsThisUsed::CruftTracker
+
+    def self.do_a_thing
+      # consider it done
+    end
+
+    def self.be_sneaky
+      # you can't see me!!
+    end
+    private_class_method :be_sneaky
+    is_this_used? :be_sneaky
+
+    def do_something
+      # Pretend I do something with these args
+    end
+
+    is_this_used? :do_something
+
+    def do_something_protectidly
+      # shh!
+    end
+    protected :do_something_protectidly
+    is_this_used? :do_something_protectidly
+
+    private
+
+    def do_something_privately
+      # shh!
+    end
+
+    is_this_used? :do_something_privately
+  end
+end

--- a/spec/dummy_app/models/fixtures/example_cruft20.rb
+++ b/spec/dummy_app/models/fixtures/example_cruft20.rb
@@ -3,36 +3,31 @@
 require 'is_this_used/cruft_tracker'
 
 module Fixtures
-  class ExampleCruft19
+  class ExampleCruft20
     include IsThisUsed::CruftTracker
 
     def self.do_a_thing
       # consider it done
     end
-    is_this_used? :do_a_thing
 
     def self.be_sneaky
       # you can't see me!!
     end
     private_class_method :be_sneaky
-    is_this_used? :be_sneaky
 
     def do_something
       # Pretend I do something with these args
     end
-    is_this_used? :do_something
 
     def do_something_protectidly
       # shh!
     end
     protected :do_something_protectidly
-    is_this_used? :do_something_protectidly
 
     private
 
     def do_something_privately
       # shh!
     end
-    is_this_used? :do_something_privately
   end
 end

--- a/spec/models/potential_cruft_spec.rb
+++ b/spec/models/potential_cruft_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'is_this_used/models/potential_cruft'
 require 'is_this_used/models/potential_cruft_stack'
+require 'dummy_app/models/fixtures/example_cruft19'
 
 RSpec.describe IsThisUsed::PotentialCruft do
   it 'can be persisted' do
@@ -10,7 +11,7 @@ RSpec.describe IsThisUsed::PotentialCruft do
       IsThisUsed::PotentialCruft.new(
         owner_name: 'Thingy',
         method_name: 'do_it',
-        method_type: 'instance_method'
+        method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD
       )
 
     expect { potential_cruft.save }.to change {
@@ -23,7 +24,7 @@ RSpec.describe IsThisUsed::PotentialCruft do
       IsThisUsed::PotentialCruft.create(
         owner_name: 'Thingy',
         method_name: 'do_it',
-        method_type: 'instance_method',
+        method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD,
         invocations: 123
       )
     IsThisUsed::PotentialCruftStack.create(
@@ -34,5 +35,111 @@ RSpec.describe IsThisUsed::PotentialCruft do
     )
 
     expect(potential_cruft.potential_cruft_stacks.count).to eq(1)
+  end
+
+  describe '#still_exists?' do
+    context 'when the class for a tracked method no longer exists' do
+      it 'is false' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Thingy',
+          method_name: 'do_it',
+          method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_exists?).to eq(false)
+      end
+    end
+
+    context 'when a tracked instance method no longer exists' do
+      it 'is false' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft19',
+          method_name: 'some_nonexistent_method',
+          method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_exists?).to eq(false)
+      end
+    end
+
+    context 'when a tracked class method no longer exists' do
+      it 'is false' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft19',
+          method_name: 'some_nonexistent_class_method',
+          method_type: IsThisUsed::CruftTracker::CLASS_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_exists?).to eq(false)
+      end
+    end
+
+    context 'when a tracked instance method exists' do
+      it 'is true' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft19',
+          method_name: 'do_something',
+          method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_exists?).to eq(true)
+      end
+    end
+
+    context 'when a tracked private instance exists' do
+      it 'is true' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft19',
+          method_name: 'do_something_privately',
+          method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_exists?).to eq(true)
+      end
+    end
+
+    context 'when a tracked protected instance exists' do
+      it 'is true' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft19',
+          method_name: 'do_something_protectidly',
+          method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_exists?).to eq(true)
+      end
+    end
+
+    context 'when a tracked class method exists' do
+      it 'is true' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft19',
+          method_name: 'do_a_thing',
+          method_type: IsThisUsed::CruftTracker::CLASS_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_exists?).to eq(true)
+      end
+    end
+
+    context 'when a tracked private class method exists' do
+      it 'is true' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft19',
+          method_name: 'be_sneaky',
+          method_type: IsThisUsed::CruftTracker::CLASS_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_exists?).to eq(true)
+      end
+    end
   end
 end

--- a/spec/models/potential_cruft_spec.rb
+++ b/spec/models/potential_cruft_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require 'is_this_used/models/potential_cruft'
 require 'is_this_used/models/potential_cruft_stack'
 require 'dummy_app/models/fixtures/example_cruft19'
+require 'dummy_app/models/fixtures/example_cruft20'
 
 RSpec.describe IsThisUsed::PotentialCruft do
   it 'can be persisted' do
@@ -139,6 +140,34 @@ RSpec.describe IsThisUsed::PotentialCruft do
         )
 
         expect(potential_cruft.still_exists?).to eq(true)
+      end
+    end
+  end
+
+  describe '#still_tracked?' do
+    context 'when it is still tracked' do
+      it 'is true' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft19',
+          method_name: 'do_something',
+          method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_tracked?).to eq(true)
+      end
+    end
+
+    context 'when it is no longer tracked' do
+      it 'is false' do
+        potential_cruft = IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft20',
+          method_name: 'do_something',
+          method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD,
+          invocations: 123
+        )
+
+        expect(potential_cruft.still_tracked?).to eq(false)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,4 +35,12 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.include ActiveSupport::Testing::TimeHelpers
+
+  config.before :all do
+    IsThisUsed::PotentialCruft.destroy_all
+  end
+
+  config.after :all do
+    IsThisUsed::PotentialCruft.destroy_all
+  end
 end

--- a/spec/support/is_this_used_spec_migrator.rb
+++ b/spec/support/is_this_used_spec_migrator.rb
@@ -10,6 +10,8 @@
 #
 # The above may indicate that we should use `Migrator` instead of
 # MigrationContext.
+require 'active_support'
+require 'active_record'
 require 'active_record/migration'
 
 # Manage migrations including running generators to build them, and cleaning up strays


### PR DESCRIPTION
The whole point behind tracking potential cruft is that you either determine that your method is no crufty, at which point you can stop tracking it, or you discover your method _is_ crufty and elect to delete the method. Cool. But what happens to the records in the assorted `potential_crufts` tables? Well, currently, they hang around. This means that if you track a method, then clean it up, that you'll continue to see the method as being potentially crufty, even though it doesn't exist anymore. 

This PR adds a few things to ITU to improve upon this. Firstly, there's a railtie that hooks into Rails and runs after Rails is initialized. Now, when Rails is initialized, ITU will check all the potential cruft records to see if they're still actually tracking anything. If a method is no longer being tracked, or the method no longer exists, or the class that a method belong to no longer exists, the potential cruft record will be marked as deleted.