### PR TITLE
Only cleanup in hook when eager loading classes

### DIFF
--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.9)
+    is_this_used (0.1.10)
       activerecord (>= 5.2)
 
 GEM

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.9)
+    is_this_used (0.1.10)
       activerecord (>= 5.2)
 
 GEM

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.9)
+    is_this_used (0.1.10)
       activerecord (>= 5.2)
 
 GEM

--- a/lib/is_this_used/cruft_tracker.rb
+++ b/lib/is_this_used/cruft_tracker.rb
@@ -87,6 +87,8 @@ module IsThisUsed
               method_type: method_type
             )
 
+          potential_cruft.update(deleted_at: nil) if potential_cruft.deleted_at.present?
+
           IsThisUsed::Registry.instance << potential_cruft
 
           target_method.owner.define_method target_method.name do |*args|

--- a/lib/is_this_used/railtie.rb
+++ b/lib/is_this_used/railtie.rb
@@ -5,7 +5,9 @@ module IsThisUsed
     initializer "is_this_used_railtie.configure_post_initialize_cleanup" do
 
       config.after_initialize do
-        IsThisUsed::CruftCleaner.clean🧹
+        if Rails.application.config.eager_load
+          IsThisUsed::CruftCleaner.clean🧹
+        end
       end
 
     rescue StandardError

--- a/lib/is_this_used/version.rb
+++ b/lib/is_this_used/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IsThisUsed
-  VERSION = '0.1.9'
+  VERSION = '0.1.10'
 end

--- a/spec/cruft_tracker_spec.rb
+++ b/spec/cruft_tracker_spec.rb
@@ -285,4 +285,21 @@ RSpec.describe IsThisUsed::CruftTracker do
       expect(arguments1.arguments).to eq(%w[x y z])
     end
   end
+
+  context "when deleted potential cruft records exist, but is_this_used? is used to track the same method" do
+    it 'undeletes the record' do
+      potential_cruft =
+        IsThisUsed::PotentialCruft.create(
+          owner_name: 'Fixtures::ExampleCruft21',
+          method_name: 'do_a_thing',
+          method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD,
+          deleted_at: 5.minutes.ago
+        )
+
+      require 'dummy_app/models/fixtures/example_cruft21'
+
+      potential_cruft.reload
+      expect(potential_cruft.deleted_at).to be_nil
+    end
+  end
 end

--- a/spec/dummy_app/models/fixtures/example_cruft21.rb
+++ b/spec/dummy_app/models/fixtures/example_cruft21.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'is_this_used/cruft_tracker'
+
+module Fixtures
+  class ExampleCruft21
+    include IsThisUsed::CruftTracker
+
+    def do_a_thing
+      # consider it done
+    end
+    is_this_used? :do_a_thing
+  end
+end


### PR DESCRIPTION
A previous version of this gem added a railtie to cleanup cruft when a rails application loads. This should only occur if the Rails application is running with `cache_classes=true`. If not, then ITU will mark cruft as deleted that's not really deleted.

This PR also adds logic to undelete potential cruft records in the case that they have been marked as deleted, but are still being tracked. For example, let's say you start tracking a method. Then you remove the `is_this_used?` for the method. ITU should clean that up next time the production app boots. However, let's say you later add the `is_this_used?` back for that method. We'd want to unmark that same potential cruft record as deleted.