### PR TITLE
Catch NoMethodError when starting to track cruft

### DIFF
--- a/gemfiles/rails_5.2.gemfile.lock
+++ b/gemfiles/rails_5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.10)
+    is_this_used (0.1.11)
       activerecord (>= 5.2)
 
 GEM

--- a/gemfiles/rails_6.0.gemfile.lock
+++ b/gemfiles/rails_6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.10)
+    is_this_used (0.1.11)
       activerecord (>= 5.2)
 
 GEM

--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    is_this_used (0.1.10)
+    is_this_used (0.1.11)
       activerecord (>= 5.2)
 
 GEM

--- a/lib/is_this_used/cruft_tracker.rb
+++ b/lib/is_this_used/cruft_tracker.rb
@@ -107,11 +107,11 @@ module IsThisUsed
             end
           end
         end
-      rescue ActiveRecord::StatementInvalid => e
+      rescue ActiveRecord::StatementInvalid, NoMethodError => e
         raise unless e.cause.present? && e.cause.instance_of?(Mysql2::Error)
 
         Rails.logger.warn(
-          'There was an error recording potential cruft. Does the potential_crufts table exist?'
+          'There was an error recording potential cruft. Does the potential_crufts table exist? Have migrations been run?'
         )
       rescue Mysql2::Error::ConnectionError, ActiveRecord::ConnectionNotEstablished
         Rails.logger.warn(

--- a/lib/is_this_used/version.rb
+++ b/lib/is_this_used/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IsThisUsed
-  VERSION = '0.1.10'
+  VERSION = '0.1.11'
 end

--- a/spec/cruft_tracker_spec.rb
+++ b/spec/cruft_tracker_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe IsThisUsed::CruftTracker do
         'RENAME TABLE potential_crufts TO tmp_potential_crufts'
       )
       expect(Rails.logger).to receive(:warn).with(
-        'There was an error recording potential cruft. Does the potential_crufts table exist?'
+        'There was an error recording potential cruft. Does the potential_crufts table exist? Have migrations been run?'
       )
 
       require 'dummy_app/models/fixtures/example_cruft13'


### PR DESCRIPTION
I recently added a feature to manage potential crufts. If a method disappears we mark the cruft record as deleted, etc. There's also a feature that undeletes a record when we start tracking it. Imagine that you're tracking a method, then stop tracking it. It'll be marked as deleted. But now you start tracking it again. It should be undeleted automatically. This feature introduced a new `deleted_at` column in the migrations and associated code to manage it.

Now imagine that you have an existing app that doesn't have that deleted_at field. You write a migration to add that AND update the gem at the same time. Because the gem runs code when classes are loaded and because the potential crufts table doesn't yet have the deleted_at column, running the migration will fail. 

This commit simply catches the `NoMethodError` that is raised and updates the warning message we already print to the console.