### PR TITLE
Fix race conditions

### DIFF
--- a/lib/generators/is_this_used/templates/create_potential_cruft_arguments.rb.erb
+++ b/lib/generators/is_this_used/templates/create_potential_cruft_arguments.rb.erb
@@ -7,6 +7,10 @@ class CreatePotentialCruftArguments < ActiveRecord::Migration<%= migration_versi
       t.json :arguments, null: false
       t.integer :occurrences, null: false, index: true, default: 0
       t.timestamps
+
+      t.index %i[potential_cruft_id arguments_hash],
+              unique: true,
+              name: 'index_pca_on_potential_cruft_id_and_arguments_hash'
     end
   end
 end

--- a/lib/generators/is_this_used/templates/create_potential_cruft_stacks.rb.erb
+++ b/lib/generators/is_this_used/templates/create_potential_cruft_stacks.rb.erb
@@ -7,6 +7,10 @@ class CreatePotentialCruftStacks < ActiveRecord::Migration<%= migration_version 
       t.json :stack, null: false
       t.integer :occurrences, null: false, index: true, default: 0
       t.timestamps
+
+      t.index %i[potential_cruft_id stack_hash],
+              unique: true,
+              name: 'index_pcs_on_potential_cruft_id_and_stack_hash'
     end
   end
 end

--- a/lib/generators/is_this_used/templates/create_potential_crufts.rb.erb
+++ b/lib/generators/is_this_used/templates/create_potential_crufts.rb.erb
@@ -11,7 +11,10 @@ class CreatePotentialCrufts < ActiveRecord::Migration<%= migration_version %>
 
       t.index :owner_name
       t.index :method_name
-      t.index %i(owner_name method_name)
+      t.index %i[owner_name method_name]
+      t.index %i[owner_name method_name method_type],
+              unique: true,
+              name: 'index_pc_on_owner_name_and_method_name_and_method_type'
     end
   end
 end

--- a/lib/is_this_used/cruft_tracker.rb
+++ b/lib/is_this_used/cruft_tracker.rb
@@ -80,12 +80,11 @@ module IsThisUsed
           method_type ||= determine_method_type(method_name)
           target_method = target_method(method_name, method_type)
 
-          potential_cruft =
-            PotentialCruft.find_or_create_by(
-              owner_name: self.name,
-              method_name: method_name,
-              method_type: method_type
-            )
+          potential_cruft = create_or_find_potential_cruft(
+            owner_name: self.name,
+            method_name: method_name,
+            method_type: method_type
+          )
 
           potential_cruft.update(deleted_at: nil) if potential_cruft.deleted_at.present?
 
@@ -149,6 +148,17 @@ module IsThisUsed
         else
           raise NoSuchMethod.new(self.name, method_name)
         end
+      end
+
+      def create_or_find_potential_cruft(owner_name:, method_name:, method_type:)
+        PotentialCruft.find_or_create_by(owner_name: self.name,
+                                         method_name: method_name,
+                                         method_type: method_type)
+
+      rescue ActiveRecord::RecordNotUnique => e
+        PotentialCruft.find_by(owner_name: self.name,
+                               method_name: method_name,
+                               method_type: method_type)
       end
     end
   end

--- a/lib/is_this_used/cruft_tracker.rb
+++ b/lib/is_this_used/cruft_tracker.rb
@@ -21,18 +21,26 @@ module IsThisUsed
 
         potential_cruft_stack =
           PotentialCruftStack.find_by(
-            potential_cruft: potential_cruft, stack_hash: stack_hash
-          )
-        potential_cruft_stack ||=
-          PotentialCruftStack.new(
-            potential_cruft: potential_cruft,
-            stack_hash: stack_hash,
-            stack: stack
+            stack_hash: stack_hash
           )
 
-        potential_cruft_stack.occurrences += 1
+        potential_cruft_stack ||= begin
+                                    PotentialCruftStack.create(
+                                      potential_cruft: potential_cruft,
+                                      stack_hash: stack_hash,
+                                      stack: stack
+                                    )
+                                  rescue ActiveRecord::RecordNotUnique
+                                    PotentialCruftStack.find_by(
+                                      stack_hash: stack_hash
+                                    )
+                                  end
 
-        potential_cruft_stack.save
+        potential_cruft_stack.with_lock do
+          potential_cruft_stack.reload
+          potential_cruft_stack.occurrences += 1
+          potential_cruft_stack.save!
+        end
       end
 
       def self.filtered_stack
@@ -55,18 +63,24 @@ module IsThisUsed
 
         potential_cruft_argument =
           PotentialCruftArgument.find_by(
-            potential_cruft: potential_cruft, arguments_hash: arguments_hash
+            arguments_hash: arguments_hash
           )
-        potential_cruft_argument ||=
-          PotentialCruftArgument.new(
-            potential_cruft: potential_cruft,
-            arguments_hash: arguments_hash,
-            arguments: arguments
-          )
+        potential_cruft_argument ||= begin
+                                       PotentialCruftArgument.create(
+                                         potential_cruft: potential_cruft,
+                                         arguments_hash: arguments_hash,
+                                         arguments: arguments
+                                       )
+                                     rescue ActiveRecord::RecordNotUnique
+                                       PotentialCruftArgument.find_by(
+                                         arguments_hash: arguments_hash
+                                       )
+                                     end
 
-        potential_cruft_argument.occurrences += 1
-
-        potential_cruft_argument.save
+        potential_cruft_argument.with_lock do
+          potential_cruft_argument.occurrences += 1
+          potential_cruft_argument.save!
+        end
       end
     end
 
@@ -81,7 +95,6 @@ module IsThisUsed
           target_method = target_method(method_name, method_type)
 
           potential_cruft = create_or_find_potential_cruft(
-            owner_name: self.name,
             method_name: method_name,
             method_type: method_type
           )
@@ -150,12 +163,12 @@ module IsThisUsed
         end
       end
 
-      def create_or_find_potential_cruft(owner_name:, method_name:, method_type:)
+      def create_or_find_potential_cruft(method_name:, method_type:)
         PotentialCruft.find_or_create_by(owner_name: self.name,
                                          method_name: method_name,
                                          method_type: method_type)
 
-      rescue ActiveRecord::RecordNotUnique => e
+      rescue ActiveRecord::RecordNotUnique
         PotentialCruft.find_by(owner_name: self.name,
                                method_name: method_name,
                                method_type: method_type)

--- a/spec/cruft_tracker_spec.rb
+++ b/spec/cruft_tracker_spec.rb
@@ -26,35 +26,33 @@ RSpec.describe IsThisUsed::CruftTracker do
     expect(hello_method.invocations).to eq(0)
   end
 
-  context 'in the case of a race condition' do
-    it 'does not create two copies of the same cruft record' do
-      starting_pistol_has_been_fired = false
+  it 'does not create multiple of the same cruft record in a race condition' do
+    starting_pistol_has_been_fired = false
 
-      threads = 10.times.map do
-        Thread.new do
-          true while !starting_pistol_has_been_fired
-          Class.new do
-            include IsThisUsed::CruftTracker
+    threads = 10.times.map do
+      Thread.new do
+        true while !starting_pistol_has_been_fired
+        Class.new do
+          include IsThisUsed::CruftTracker
 
-            def self.name
-              "SomeClassName"
-            end
-
-            def foo; end
-            is_this_used? :foo
+          def self.name
+            "SomeClassName"
           end
+
+          def foo; end
+          is_this_used? :foo
         end
       end
-      starting_pistol_has_been_fired = true
-      threads.each(&:join)
-
-      crufts = IsThisUsed::PotentialCruft.where(
-        owner_name: 'SomeClassName',
-        method_name: 'foo',
-        method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD
-      )
-      expect(crufts.count).to eq(1)
     end
+    starting_pistol_has_been_fired = true
+    threads.each(&:join)
+
+    crufts = IsThisUsed::PotentialCruft.where(
+      owner_name: 'SomeClassName',
+      method_name: 'foo',
+      method_type: IsThisUsed::CruftTracker::INSTANCE_METHOD
+    )
+    expect(crufts.count).to eq(1)
   end
 
   it 'tracks when a method is invoked' do
@@ -94,6 +92,28 @@ RSpec.describe IsThisUsed::CruftTracker do
       expect(stacks.second.occurrences).to eq(2)
       expect(stacks.second.stack.first['base_label']).to eq('do_it')
     end
+  end
+
+  it 'does not create multiple of the same stack record in a race condition' do
+    starting_pistol_has_been_fired = false
+    require 'dummy_app/models/fixtures/example_cruft22'
+
+    threads = 10.times.map do
+      Thread.new do
+        true while !starting_pistol_has_been_fired
+        Fixtures::ExampleCruft22.new.do_something
+      end
+    end
+    starting_pistol_has_been_fired = true
+    threads.each(&:join)
+
+    expect(IsThisUsed::PotentialCruftStack.count).to eq(1)
+    # I'm not asserting the exact number of occurrences because we still have a race condition
+    # related to having loaded multiple instances of PotentialCruftStack in memory and I don't want
+    # to have to jump through a zillion hoops to have exactly correct counts. It's not worth the
+    # effort and the impact is low. We could conceivably lose a few occurrence increments, but who
+    # cares?
+    expect(IsThisUsed::PotentialCruftStack.first.occurrences).to be > 1
   end
 
   context 'when the method does not exist' do
@@ -297,6 +317,29 @@ RSpec.describe IsThisUsed::CruftTracker do
       arguments2 = potential_cruft.potential_cruft_arguments.second
       expect(arguments2.arguments).to eq([2, "blargh", true, [2, "baz", false], [{ "a" => 1, "b" => "bar" }, { "a" => 2, "b" => "foo" }], { "x" => 213, "y" => true, "z" => "whatever" }])
       expect(arguments2.occurrences).to eq(2)
+    end
+
+    it 'does not create multiple of the same arguments record in a race condition' do
+      starting_pistol_has_been_fired = false
+      require 'dummy_app/models/fixtures/example_cruft23'
+
+      threads = 10.times.map do
+        Thread.new do
+          true while !starting_pistol_has_been_fired
+          example = Fixtures::ExampleCruft23.new
+          example.do_something(1, "blargh", true, [2, "baz", false], [{ a: 1, b: "bar" }, { a: 2, b: "foo" }], x: 213, y: true, z: "whatever")
+        end
+      end
+      starting_pistol_has_been_fired = true
+      threads.each(&:join)
+
+      expect(IsThisUsed::PotentialCruftArgument.count).to eq(1)
+      # I'm not asserting the exact number of occurrences because we still have a race condition
+      # related to having loaded multiple instances of PotentialCruftStack in memory and I don't want
+      # to have to jump through a zillion hoops to have exactly correct counts. It's not worth the
+      # effort and the impact is low. We could conceivably lose a few occurrence increments, but who
+      # cares?
+      expect(IsThisUsed::PotentialCruftArgument.first.occurrences).to be > 1
     end
   end
 

--- a/spec/dummy_app/db/migrate/20220120084312_set_up_test_tables.rb
+++ b/spec/dummy_app/db/migrate/20220120084312_set_up_test_tables.rb
@@ -18,6 +18,9 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.index :owner_name
       t.index :method_name
       t.index %i[owner_name method_name]
+      t.index %i[owner_name method_name method_type],
+              unique: true,
+              name: 'index_pc_on_owner_name_and_method_name_and_method_type'
     end
 
     create_table :potential_cruft_stacks do |t|
@@ -26,6 +29,10 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.json :stack, null: false
       t.integer :occurrences, null: false, index: true, default: 0
       t.timestamps
+
+      t.index %i[potential_cruft_id stack_hash],
+              unique: true,
+              name: 'index_pcs_on_potential_cruft_id_and_stack_hash'
     end
 
     create_table :potential_cruft_arguments do |t|
@@ -34,6 +41,10 @@ class SetUpTestTables < ::ActiveRecord::Migration::Current
       t.json :arguments, null: false
       t.integer :occurrences, null: false, index: true, default: 0
       t.timestamps
+
+      t.index %i[potential_cruft_id arguments_hash],
+              unique: true,
+              name: 'index_pca_on_potential_cruft_id_and_arguments_hash'
     end
   end
 

--- a/spec/dummy_app/models/fixtures/example_cruft22.rb
+++ b/spec/dummy_app/models/fixtures/example_cruft22.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'is_this_used/cruft_tracker'
+
+module Fixtures
+  class ExampleCruft22
+    include IsThisUsed::CruftTracker
+
+    def do_something
+      # consider it done
+    end
+    is_this_used? :do_something
+  end
+end

--- a/spec/dummy_app/models/fixtures/example_cruft23.rb
+++ b/spec/dummy_app/models/fixtures/example_cruft23.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'is_this_used/cruft_tracker'
+
+module Fixtures
+  class ExampleCruft23
+    include IsThisUsed::CruftTracker
+
+    def do_something(number, string, boolean, array, array_of_hashes, hash)
+      # Pretend I do something with these args
+    end
+
+    is_this_used? :do_something, track_arguments: true
+  end
+end


### PR DESCRIPTION
In distributed systems (such as those that use services like sidekiq, resque, rails, etc, at the same time may run into race conditions as the app loads or records cruft. These result in duplicate records being created in the assorted potential cruft tables.

This PR does a few things to address this. Firstly, unique indexes are added to all three tables to prevent the duplicate records. Secondly, when creating new `potential_crufts` (EG on app load), if we do run into a duplicate error, `ActiveRecord::RecordNotUnique`, we catch it and simply find the `potential_crufts` record that already exists. This mimics how `create_or_find_by` works in Rails 6, but it also works on Rails 5. 

The same basic pattern is followed when recording stacks and arguments. The only real challenge here is that we can lose occurrence increments in race conditions. Basically, we might have load the same stack or argument record at the same time in different processes. Both instances may think the occurrences is initially 10. Even if both increment and save, the total persisted will be 11, not 12. I've decided that this is an acceptable loss of precision given the level of effort required to keep this consistent.